### PR TITLE
Fix case when we try to extend null or undefined => object

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,11 @@ return function underscoreDeepExtend(obj) {
       }
       else if (_.isObject(obj[prop]) || _.isObject(source[prop])){
         if (!_.isObject(obj[prop]) || !_.isObject(source[prop])){
-          throw new Error('Trying to combine an object with a non-object (' + prop + ')');
+          if( _.isNull(obj[prop]) || _.isUndefined(obj[prop]) ) {
+            obj[prop] = _.deepExtend({}, source[prop]);
+          } else {
+            throw new Error('Trying to combine an object with a non-object (' + prop + ')');
+          }
         } else {
           obj[prop] = _.deepExtend(_.clone(obj[prop]), source[prop]);
         }


### PR DESCRIPTION
There is a behavior which should not happens in my opinion:

```
_.deepExtend( { anObject: null }, { anObject: { value: "is now assigned" } } )
```

This would result in an error in the base code. Doesn't `null` and `undefined` be considerated as non-existent object (or void pointer), so as object and should be reassigned when they are extended?

I understand if it's not the opinion of the author, but if it is, here's the pull request !

Regards,

Yacine.